### PR TITLE
Allow custom file for env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,19 @@ Add the following to `.gitignore`:
     $ heroku config:push
     Config in .env written to example
 
+    # Optional --env will use specific env file
+    $ heroku config:pull --env=production.env
+    Config for example written to production.env
+
 ## How it works
 
 Your environment will be stored locally in a file named `.env`. This
 file can be read by [foreman](http://github.com/ddollar/foreman) to load
 the local environment for your app.
 
-Please remember to not commit your `.env` file to your repository.
+To use a file other than the default `.env`, use the --env parameter.
+
+Please remember to not commit your `.env` files to your repository.
 
 ## License
 

--- a/lib/config/heroku/command/config.rb
+++ b/lib/config/heroku/command/config.rb
@@ -10,7 +10,7 @@ class Heroku::Command::Config
   #
   # -i, --interactive  # prompt whether to overwrite each config var
   # -o, --overwrite    # overwrite existing config vars
-  # -f, --filename _   # specify target filename
+  # -e, --env ENV      # specify target filename
   #
   def pull
     interactive = options[:interactive]
@@ -29,7 +29,7 @@ class Heroku::Command::Config
   #
   # -i, --interactive  # prompt whether to overwrite each config var
   # -o, --overwrite    # overwrite existing config vars
-  # -f, --filename _   # specify source filename
+  # -e, --env ENV      # specify source filename
   #
   def push
     interactive = options[:interactive]
@@ -54,7 +54,7 @@ private ######################################################################
   end
 
   def local_config_filename
-    @local_config_filename ||= options[:filename] || '.env'
+    @local_config_filename ||= options[:env] || '.env'
   end
 
   def remote_config


### PR DESCRIPTION
By using `--env/-e` you can specify which file you want to use when pulling and pushing variables.
