### PR TITLE
Fixes #8: recogineze quotes arround values in .env

### DIFF
--- a/lib/config/heroku/command/config.rb
+++ b/lib/config/heroku/command/config.rb
@@ -44,8 +44,10 @@ private ######################################################################
 
   def local_config
     File.read(local_config_filename).split("\n").inject({}) do |hash, line|
-      if line =~ /\A([A-Za-z0-9_]+)=(.*)\z/
-        hash[$1] = $2
+      if /\A(?<key>[A-Za-z0-9_]+)=(?<value>.*)\z/ =~ line
+        hash[key] = value
+        hash[key].gsub!(/\A"(.*?)"\z/, '\1')
+        hash[key].gsub!(/\A'(.*?)'\z/, '\1')
       end
       hash
     end


### PR DESCRIPTION
Added a check to see if there are quotes (single or double) arround the value.
If there are the same kind of quotes around each side: remove them.

This commit also removes the usage of $1 and $2 variables for accessing the
backreferences because the added gsubs()'s overwrite those values. Named
captures are used instead.
