### PR TITLE
Allow variables names to contain dots

### DIFF
--- a/lib/config/heroku/command/config.rb
+++ b/lib/config/heroku/command/config.rb
@@ -44,7 +44,7 @@ private ######################################################################
 
   def local_config
     File.read(local_config_filename).split("\n").inject({}) do |hash, line|
-      if line =~ /\A([A-Za-z0-9_]+)=(.*)\z/
+      if line =~ /\A([A-Za-z0-9_\.]+)=(.*)\z/
         hash[$1] = $2
       end
       hash


### PR DESCRIPTION
Hello,

I needed to manage keys containing dots in their names, there seems to be not restriction from heroku on this matter.
I don't know if there this is compatible with foreman. If it is could you merge this very simple pull request ?

Thanks !
