### PR TITLE
Trim quotes on value

### DIFF
--- a/lib/config/heroku/command/config.rb
+++ b/lib/config/heroku/command/config.rb
@@ -53,7 +53,8 @@ private ######################################################################
   def local_config
     File.read(local_config_filename).split("\n").inject({}) do |hash, line|
       if line =~ /\A([A-Za-z0-9_]+)=(.*)\z/
-        hash[$1] = $2
+        key, value = $1, $2
+        hash[key] = value.gsub(/\A(?:'|")(.*)(?:'|")\z/) { $1 }
       end
       hash
     end


### PR DESCRIPTION
I want to write `.env` file with quotes. So it is nice heroku-config trims those quotes.

``` ruby
# REPL
hash = {}
line = %(KEY='abcde4567abcd')

if line =~ /\A([A-Za-z0-9_]+)=(.*)\z/ then hash[$1] = $2.gsub(/\A(?:'|")(.*)(?:'|")\z/) { $1 } end
hash #=> {"KEY"=>"abcde4567abcd"}

line = %(KEY='abcde4'567abcd')
if line =~ /\A([A-Za-z0-9_]+)=(.*)\z/ then hash[$1] = $2.gsub(/\A(?:'|")(.*)(?:'|")\z/) { $1 } end
hash #=> {"KEY"=>"abcde4'567abcd"}
```

Thanks for nice gem! :gem: 
