### PR TITLE
Error out if variable line does not match regex (is improper format)

### DIFF
--- a/lib/config/heroku/command/config.rb
+++ b/lib/config/heroku/command/config.rb
@@ -55,13 +55,16 @@ private ######################################################################
     config_data = (STDIN.tty?) ? File.read(local_config_filename) : STDIN.read
     config_data.split("\n").inject({}) do |hash, line|
       # Regexp removes leading " from value
-      if line =~ /\A([A-Za-z0-9_]+)="?(.*)\z/
+      if line =~ /\A([A-Za-z0-9_]+)="?([^\"]+|\\.)*"?\z/
 
         # Remove trailing " from value
         v = $2.chomp('"')
 
         # Let YAML parse the value back (with newlines, etc)
         hash[$1] = YAML.load(%Q(---\n"#{v}"\n))
+      elsif line != ""
+        puts "ERROR: invalid format (should be FOO=bar) --> '#{line}' "
+        exit 0
       end
       hash
     end

--- a/lib/config/heroku/command/config.rb
+++ b/lib/config/heroku/command/config.rb
@@ -49,6 +49,16 @@ class Heroku::Command::Config
     end
   end
 
+  # config:check
+  #
+  # Reads in local config and displays hash
+  #
+  def check
+    display "Checking .env file..."
+    display "Local config interpreted as:\n #{local_config.inspect}"
+    display "Done."
+  end
+
 private ######################################################################
 
   def local_config
@@ -63,8 +73,7 @@ private ######################################################################
         # Let YAML parse the value back (with newlines, etc)
         hash[$1] = YAML.load(%Q(---\n"#{v}"\n))
       elsif line != ""
-        puts "ERROR: invalid format (should be FOO=bar) --> '#{line}' "
-        exit 0
+        display "WARNING: invalid format (should be FOO=bar) --> '#{line}' "
       end
       hash
     end


### PR DESCRIPTION
Fixes #29 

Exits if variables do not match the regex (vars should always be `FOO=bar`)

```
➜  tmp  heroku config:push -a young-spire-4198
WARNING: invalid format (should be FOO=bar) --> 'FOO = bar'
```

