### PR TITLE
Added support to single-quotes value wrapping.

### DIFF
--- a/lib/config/heroku/command/config.rb
+++ b/lib/config/heroku/command/config.rb
@@ -55,10 +55,10 @@ private ######################################################################
     config_data = (STDIN.tty?) ? File.read(local_config_filename) : STDIN.read
     config_data.split("\n").inject({}) do |hash, line|
       # Regexp removes leading " from value
-      if line =~ /\A([A-Za-z0-9_]+)="?(.*)\z/
+      if line =~ /\A([A-Za-z0-9_]+)=["']?(.*)\z/
 
         # Remove trailing " from value
-        v = $2.chomp('"')
+        v = $2.sub(/["']$/, "")
 
         # Let YAML parse the value back (with newlines, etc)
         hash[$1] = YAML.load(%Q(---\n"#{v}"\n))


### PR DESCRIPTION
As this is supported by dotenv/bash so should it be by heroku-config.